### PR TITLE
Add GitHub workflows for creating releases and formatting Terraform f…

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,58 @@
+name: Create Release
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  semantic-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: paulhatch/semantic-version@v5.4.0
+        id: generate-version
+        with:
+          major_pattern: "(MAJOR)"
+          minor_pattern: "(MINOR)"
+          version_format: "v${major}.${minor}.${patch}"
+          # bump_each_commit: true
+
+    outputs:
+      version: ${{ steps.generate-version.outputs.version }}
+
+  release:
+    if: github.event_name == 'push'
+    needs: [semantic-version]
+    runs-on: ubuntu-latest
+    env:
+      TARGET_TAG: "${{ needs.semantic-version.outputs.version }}"
+    steps:
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ env.TARGET_TAG }}" \
+              --repo="${GITHUB_REPOSITORY}" \
+              --title="${{ env.TARGET_TAG }}" \
+              --generate-notes \
+              --notes "- Leaving note as an example of manual notes" || echo "Release already exists, proceeding to edit release notes" \
+          gh release edit "${{ env.TARGET_TAG }}" \
+              --repo="${GITHUB_REPOSITORY}" \
+              --notes "- Leaving note as an example of manual notes"
+
+      - name: Generate Summary
+        if: always()
+        run: |
+          cat > $GITHUB_STEP_SUMMARY << EOL
+          ## Create Release (Only generated when merging a PR to main)
+          New Release 🔗: [${{ env.TARGET_TAG }}](${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ env.TARGET_TAG }})
+          EOL

--- a/.github/workflows/terraform-format.yaml
+++ b/.github/workflows/terraform-format.yaml
@@ -1,0 +1,37 @@
+name: "Terraform Format"
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  terraform_fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Fmt
+        run: terraform fmt
+
+      - name: Commit and Push new changes
+        id: commit-and-push
+        run: |
+          echo SYNC_BRANCH=$(git config user.name github-actions && git config user.email github-actions@github.com && git add . && git commit -m "Saving new cahnges for ${{ github.head_ref }} branch" && git push) >> $GITHUB_OUTPUT
+
+      - name: Generate job summary
+        if: always()
+        run: |
+          cat > "$GITHUB_STEP_SUMMARY" << EOL
+
+          ### Branch Sync
+          ${{ steps.commit-and-push.outputs.SYNC_BRANCH }}
+
+          EOL

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,19 @@
+resource "aws_ec2_tag" "private_subnets_karpenter_tag" {
+  for_each    = toset(var.private_subnets_ids)
+  resource_id = each.value
+  key         = "karpenter.sh/cluster/${var.cluster_name}"
+  value       = "discovery"
+}
+
+resource "aws_ec2_tag" "private_subnets_internal_elb_tag" {
+  for_each    = toset(var.private_subnets_ids)
+  resource_id = each.value
+  key         = "kubernetes.io/role/internal-elb"
+  value       = "1"
+}
+resource "aws_ec2_tag" "private_subnets_external_elb_tag" {
+  for_each    = toset(var.public_subnets_ids)
+  resource_id = each.value
+  key         = "kubernetes.io/role/elb"
+  value       = "1"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,14 @@
+variable "cluster_name" {
+  description = "Name of the EKS cluster"
+  type        = string
+}
+
+variable "private_subnets_ids" {
+  description = "List of subnets IDs to tag"
+  type        = list(string)
+}
+
+variable "public_subnets_ids" {
+  description = "List of public subnets IDs to tag"
+  type        = list(string)
+}


### PR DESCRIPTION
…iles

This commit adds two new GitHub workflows:
- create-release.yml: This workflow is triggered on pull requests and pushes to the main branch. It uses the semantic-version action to generate a new version based on commit messages and creates a release using the GitHub CLI.
- terraform-format.yaml: This workflow is triggered on pull requests to the main branch. It uses the hashicorp/setup-terraform action to format Terraform files and commits the changes.

New files added:
- .github/workflows/create-release.yml
- .github/workflows/terraform-format.yaml

New code added:
- Added resource blocks in main.tf to tag AWS EC2 instances with specific key-value pairs.
- Added variables.tf file to define input variables for the Terraform configuration.